### PR TITLE
Remove arch from DesktopAppInstaller to support ARM64.

### DIFF
--- a/WinGet-Wrapper.ps1
+++ b/WinGet-Wrapper.ps1
@@ -135,7 +135,7 @@ if ($env:USERNAME -like "*$env:COMPUTERNAME*") {
 # Find WinGet.exe Location
 if ($Context -contains "Machine"){
 try {
-    $resolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe"
+    $resolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*__8wekyb3d8bbwe"
     if ($resolveWingetPath) {
         $wingetPath = $resolveWingetPath[-1].Path
         $wingetPath = $wingetPath + "\winget.exe"

--- a/WinGet-WrapperDetection.ps1
+++ b/WinGet-WrapperDetection.ps1
@@ -111,7 +111,7 @@ if ($env:USERNAME -like "*$env:COMPUTERNAME*") {
 # Find WinGet.exe Location
 if ($Context -contains "Machine"){
     try {
-        $resolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe"
+        $resolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*__8wekyb3d8bbwe"
         if ($resolveWingetPath) {
             $wingetPath = $resolveWingetPath[-1].Path
             $wingetPath = $wingetPath + "\winget.exe"

--- a/WinGet-WrapperRequirements.ps1
+++ b/WinGet-WrapperRequirements.ps1
@@ -32,7 +32,7 @@ if ($env:USERNAME -like "*$env:COMPUTERNAME*") {
 # Find WinGet.exe Location
 if ($Context -contains "Machine"){
     try {
-        $resolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe"
+        $resolveWingetPath = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*__8wekyb3d8bbwe"
         if ($resolveWingetPath) {
             $wingetPath = $resolveWingetPath[-1].Path
             $wingetPath = $wingetPath + "\winget.exe"


### PR DESCRIPTION
When using the winget wrapper on ARM64/Snapdragon devices. The scripts fail as it's looking specifically for 'x64' in the folder name. For ARM64 versions of windows, it is "arm". 

I propose removing the architecture from the string and let the wildcard handle selection of the right WinGet path.